### PR TITLE
Add `Remotes` field in `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,5 +20,7 @@ Imports:
     jsonify,
     rlang (>= 1.1.0),
     sf
+Remotes:
+    R-ArcGIS/arcgisutils
 Config/rextendr/version: 0.3.1.9000
 SystemRequirements: Cargo (Rust's package manager), rustc


### PR DESCRIPTION
Just ran into the issue "R-ArcGIS/arcgeocode: Can't install dependency arcgisutils (>= 0.2.0.9000)" because it was looking for this version on CRAN